### PR TITLE
del extra `<%= pkg.name %>`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ module.exports = function(grunt) {
         pkg: grunt.file.readJSON('package.json'),
         uglify: {
             options: {
-                banner: '/*! <%= pkg.name %> <%= pkg.name %> v<%= pkg.version %> <%= grunt.template.today("yyyy-mm-dd") %> */\n'
+                banner: '/*! <%= pkg.name %> v<%= pkg.version %> <%= grunt.template.today("yyyy-mm-dd") %> */\n'
             },
             build: {
                 files: {


### PR DESCRIPTION
I'm sure you don't need an extra `<%= pkg.name %>`.
I wish there was a `file.name` since you distribute 2/3 files, but Google won't find it for me.
