### PR TITLE
+ jsDelivr CDN instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,15 @@ INSTALL
 ```sh
 $ bower install lining.js
 ```
+
+### CDN
+
+jsDelivr provides free CDN hosting which helps speed webpage loading.  Usage is simple:
+```html
+<script src="//cdn.jsdelivr.net/lining.js/VERSION/lining.min.js"></script>
+```
+then change `VERSION` with the version number you can find [hosted at jsDelivr](http://www.jsdelivr.com/#!lining.js).<br>
+If you want to also use effects, you can take advantage of collating and reduce a HTTP request:
+```html
+<script src="//cdn.jsdelivr.net/g/lining.js@VERSION(lining.min.js+lining.effect.min.js)"></script>
+```


### PR DESCRIPTION
There are [more tricks](https://github.com/jsdelivr/jsdelivr#usage), but I wanted to keep it simple with the most useful shortcut.
